### PR TITLE
Backported to Delphi 2007

### DIFF
--- a/ObjectDebugger.dpk
+++ b/ObjectDebugger.dpk
@@ -30,8 +30,11 @@ package ObjectDebugger;
 requires
   rtl,
   vcl,
-  vclimg,
-  vclwinx;
+  vclimg
+  {$IFDEF UNICODE}
+  , vclwinx
+  {$ENDIF}
+  ;
 
 contains
   ObjectDebuggerForm in 'ObjectDebuggerForm.pas' {CantObjDebForm};

--- a/ObjectDebuggerForm.dfm
+++ b/ObjectDebuggerForm.dfm
@@ -243,26 +243,6 @@ object CantObjDebForm: TCantObjDebForm
       TabOrder = 1
       OnChange = cbFormsChange
     end
-    object edFilter: TButtonedEdit
-      AlignWithMargins = True
-      Left = 4
-      Top = 58
-      Width = 312
-      Height = 21
-      Align = alTop
-      Images = ImageList1
-      LeftButton.Enabled = False
-      LeftButton.ImageIndex = 1
-      LeftButton.Visible = True
-      RightButton.Hint = 'Clear the filter'
-      RightButton.ImageIndex = 0
-      RightButton.Visible = True
-      TabOrder = 2
-      TextHint = 'Type to filter...'
-      OnChange = SearchBox1Change
-      OnKeyDown = edFilterKeyDown
-      OnRightButtonClick = edFilterRightButtonClick
-    end
   end
   object ColorDialog1: TColorDialog
     Left = 96

--- a/ObjectDebuggerForm.inc
+++ b/ObjectDebuggerForm.inc
@@ -1,0 +1,4 @@
+// The compiler version is higher than Delphi 2007's.
+{$IFDEF UNICODE}
+  {$DEFINE D2007_UP}
+{$ENDIF}


### PR DESCRIPTION
Dear Maintainers,

I am writing to request the inclusion of this pull request, which backports the Object Debugger project to Delphi 7 and 2007. 

**Changes:**
- Replaced `TButtonedEdit` with `TEdit` for Delphi 2007 compatibility, adding conditional compilation for versions that support `TButtonedEdit`.
- Replaced regex matching for colors with a native function to determine valid hex colors.
- Added a new include file `ObjectDebuggerForm.inc` to manage version-specific compiler directives.
- Modified `ObjectDebugger.dpk` to conditionally include `vclwinx`
- Adjusted the uses clause in `ObjectDebuggerForm.pas` to conditionally include `Vcl.WinXCtrls`, `System.ImageList`, and `Vcl.ImgList`.

I have thoroughly tested the changes to ensure compatibility and maintain the integrity of the original features. I believe this contribution will be valuable to the community and align with the goals of the project.

Please review and merge these changes at your earliest convenience. Thank you for considering this request.

Best regards,  
Dimitar Grigorov